### PR TITLE
More possible nulls

### DIFF
--- a/include/modules/audio/audio_spec.ts
+++ b/include/modules/audio/audio_spec.ts
@@ -11,7 +11,7 @@ let timeUnit: TimeUnit;
  * https://love2d.org/wiki/RecordingDevice
  * Obtained 2019/03/02
  */
-let recordingDevice: RecordingDevice;
+declare const recordingDevice: RecordingDevice;
 recordingDevice.release;
 recordingDevice.type;
 recordingDevice.typeOf;
@@ -29,7 +29,7 @@ recordingDevice.stop;
  * Documented at
  * https://love2d.org/wiki/Source
  */
-let source: Source;
+declare const source: Source;
 source.release;
 source.type;
 source.typeOf;

--- a/include/modules/audio/love.audio.d.ts
+++ b/include/modules/audio/love.audio.d.ts
@@ -33,8 +33,7 @@ declare namespace love {
 
         /**
          * Gets the current global scale factor for velocity-based doppler effects.
-         *
-         * @return `scale` The current doppler scale factor.
+         * @return `scale` The current doppler scale factor. Default is `1`.
          * @link [love.audio.getDopplerScale](https://love2d.org/wiki/love.audio.getDopplerScale)
          * @since 0.9.2
          */
@@ -43,10 +42,11 @@ declare namespace love {
         /**
          * Gets the settings associated with an effect.
          * @param name The name of the effect.
+         * @return `settings` The settings associated with the effect or _nil_.
          * @link [love.audio.getEffect](https://love2d.org/wiki/love.audio.getEffect)
          * @since 11.0
          */
-        export function getEffect(name: string): EffectSettings;
+        export function getEffect(name: string): EffectSettings | null;
 
         /**
          * Gets the maximum number of active effects supported by the system.
@@ -139,7 +139,7 @@ declare namespace love {
          * @link [love.audio.newQueueableSource](https://love2d.org/wiki/love.audio.newQueueableSource)
          * @since 11.0
          */
-        export function newQueueableSource(samplerate: number, bitdepth: 8 | 16, channels: number, buffercount?: number): Source;
+        export function newQueueableSource(samplerate: number, bitdepth: 8 | 16, channels: 1 | 2, buffercount?: number): Source;
 
         /**
          * Creates a new Source.

--- a/include/modules/audio/types/RecordingDevice.d.ts
+++ b/include/modules/audio/types/RecordingDevice.d.ts
@@ -23,11 +23,11 @@ declare interface RecordingDevice extends Object {
 
     /**
      * Gets all recorded audio [SoundData](https://love2d.org/wiki/SoundData) stored in the device's internal ring buffer.
-     * @return `data` The recorded audio data, or nil if the device isn't recording.
+     * @return `data` The recorded audio data, or _nil/null_ if the device isn't recording.
      * @link [RecordingDevice:getData](https://love2d.org/wiki/RecordingDevice:getData)
      * @since 11.0
      */
-    getData(): SoundData;
+    getData(): SoundData | null;
 
     /**
      * Gets the name of the recording device.
@@ -75,10 +75,10 @@ declare interface RecordingDevice extends Object {
 
     /**
      * Stops recording audio from this device. Any sound data currently in the device's buffer will be returned.
-     * @return `data` The sound data currently in the device's buffer, or nil if the device wasn't recording.
+     * @return `data` The sound data currently in the device's buffer, or _nil/null_ if the device wasn't recording.
      * @link [RecordingDevice:stop](https://love2d.org/wiki/RecordingDevice:stop)
      * @since 11.0
      */
-    stop(): SoundData;
+    stop(): SoundData | null;
 
 }

--- a/include/modules/audio/types/Source.d.ts
+++ b/include/modules/audio/types/Source.d.ts
@@ -92,19 +92,19 @@ declare interface Source extends Object {
      * This function returns undefined if the effect was applied with no filter settings associated to it.
      * @param name The name of the effect.
      * @param filtersettings An optional empty table that will be filled with the filter settings.
-     * @return `filtersettings` The settings for the filter associated to this effect, or nil if the effect is not present in this Source or has no filter associated.
+     * @return `filtersettings` The settings for the filter associated to this effect, or _nil/null_ if the effect is not present in this Source or has no filter associated.
      * @link [Source:getEffect](https://love2d.org/wiki/Source:getEffect)
      * @since 11.0
      */
-    getEffect(name: string, filtersettings?: object): { volume: number, highgain: number, lowgain: number };
+    getEffect(name: string, filtersettings?: object): { volume: number, highgain: number, lowgain: number } | null;
 
     /**
      * Gets the filter settings currently applied to the Source.
-     * @return `settings` The filter settings to use for this Source, or nil if the Source has no active filter.
+     * @return `settings` The filter settings to use for this Source, or nil/null if the Source has no active filter.
      * @link [Source:getFilter](https://love2d.org/wiki/Source:getFilter)
      * @since 11.0
      */
-    getFilter(): FilterSettings;
+    getFilter(): FilterSettings | null;
 
     /**
      * Gets the number of free buffer slots in a queueable Source.

--- a/include/modules/data/data_spec.ts
+++ b/include/modules/data/data_spec.ts
@@ -9,7 +9,7 @@ let hashFunction: HashFunction;
  * https://love2d.org/wiki/ByteData
  * Obtained 2019/03/02
  */
-let byteData: ByteData;
+declare const byteData: ByteData;
 byteData.clone;
 byteData.getPointer;
 byteData.getSize;
@@ -23,7 +23,7 @@ byteData.typeOf;
  * https://love2d.org/wiki/Data
  * Obtained 2019/03/02
  */
-let data: Data;
+declare const data: Data;
 data.clone;
 data.getPointer;
 data.getSize;

--- a/include/modules/filesystem/filesystem_spec.ts
+++ b/include/modules/filesystem/filesystem_spec.ts
@@ -5,7 +5,7 @@ let fileDecoder: FileDecoder;
  * https://love2d.org/wiki/File
  * 2019/03/02
  */
-let file: File;
+declare const file: File;
 file.close;
 file.flush;
 file.getBuffer;

--- a/include/modules/filesystem/love.filesystem.d.ts
+++ b/include/modules/filesystem/love.filesystem.d.ts
@@ -13,12 +13,12 @@ declare namespace love {
          * @param name The name (and path) of the file.
          * @param data The data that should be written to the file
          * @param size How many bytes to write.
-         * @return {boolean} success, True if the operation was successful, or nil if there was an error.
-         * @return {string} errormsg, The error message on failure.
+         * @return success, True if the operation was successful, or _nil/null_ if there was an error.
+         * @return errormsg, The error message on failure.
          * @tupleReturn
          * @link [love.filesystem.append](https://love2d.org/wiki/love.filesystem.append)
          */
-        export function append(name: string, data: string, size?: number): [boolean, string];
+        export function append(name: string, data: string, size?: number): [true] | [null, string];
 
         /**
          * Gets whether love.filesystem follows symbolic links.
@@ -103,31 +103,22 @@ declare namespace love {
          * Gets information about the specified file or directory.
          *
          * @param path The file or directory path to check.
-         * @return {table} info, A table containing information about the specified path, or nil if nothing exists at the path. The table contains the following fields:
-         * @link [love.filesystem.getInfo](https://love2d.org/wiki/love.filesystem.getInfo)
-         */
-        export function getInfo(path: string): FileInfo;
-
-        /**
-         * Gets information about the specified file or directory.
-         *
-         * @param path The file or directory path to check.
          * @param info A table which will be filled in with info about the specified path.
-         * @return {table} info, A table containing information about the specified path, or nil if nothing exists at the path. The table contains the following fields:
+         * @return info, A table containing information about the specified path, or _nil/null_ if nothing exists at the path.
          * @link [love.filesystem.getInfo](https://love2d.org/wiki/love.filesystem.getInfo)
          */
-        export function getInfo(path: string, info: object): FileInfo;
+        export function getInfo(path: string, info?: object): FileInfo | null;
 
         /**
          * Gets the last modification time of a file.
          * @param filename The path and name to a file.
-         * @return modtime, The last modification time in seconds since the unix epoch or nil on failure.
+         * @return modtime, The last modification time in seconds since the unix epoch or _nil/null_ on failure.
          * @return errormsg, The error message on failure.
          * @tupleReturn
          * @link [love.filesystem.getLastModified](https://love2d.org/wiki/love.filesystem.getLastModified)
          * @deprecated 11.0
          */
-        export function getLastModified(filename: string): [number, string];
+        export function getLastModified(filename: string): [number | null, string | null];
 
         /**
          * Gets the platform-specific absolute path of the directory containing a
@@ -175,12 +166,12 @@ declare namespace love {
         /**
          * Gets the size in bytes of a file.
          * @param filename The path and name to a file.
-         * @return size, The size in bytes of the file, or nil on failure.
+         * @return size, The size in bytes of the file, or _nil/null_ on failure.
          * @return errormsg, The error message on failure.
          * @link [love.filesystem.getSize](https://love2d.org/wiki/love.filesystem.getSize)
          * @deprecated since 11.0. This function is deprecated and is replaced by love.filesystem.getInfo.
          */
-        export function getSize(filename: string): [number, string];
+        export function getSize(filename: string): [number | null, string | null];
 
         /**
          * Returns the full path to the the .love file or directory. If the game is fused
@@ -314,11 +305,11 @@ declare namespace love {
          *
          * @param filename The filename of the file to read.
          * @param mode The mode to open the file in.
-         * @return {File} file, The new File object, or nil if an error occurred.
-         * @return {string} errorstr, The error string if an error occurred.
+         * @return file, The new File object, or _nil/null_ if an error occurred.
+         * @return errorstr, The error string if an error occurred.
+         * @tupleReturn
          */
-        /** @tupleReturn */
-        export function newFile(filename: string, mode?: FileMode): [File, string];
+        export function newFile(filename: string, mode?: FileMode): [File | null, string | null];
 
         /**
          * Creates a new FileData object.
@@ -334,22 +325,22 @@ declare namespace love {
          * Creates a new FileData object.
          *
          * @param filepath Path to the file.
-         * @return {FileData} data, The new FileData, or nil if an error occurred.
-         * @return {string} err, The error string, if an error occurred.
+         * @return data, The new FileData, or _nil/null_ if an error occurred.
+         * @return err, The error string, if an error occurred.
+         * @tupleReturn
          */
-        /** @tupleReturn */
-        export function newFileData(filepath: string): [FileData, string];
+        export function newFileData(filepath: string): [FileData | null, string | null];
 
         /**
          * Read the contents of a file.
          *
          * @param name The name (and path) of the file.
          * @param bytes How many bytes to read.
-         * @return {string} contents, The file contents.
-         * @return {number} size, How many bytes have been read.
+         * @return contents, The file contents, or _nil/null_ if an error occurred.
+         * @return size, How many bytes have been read, or the error string.
+         * @tupleReturn
          */
-        /** @tupleReturn */
-        export function read(name: string, bytes?: number): [string, number];
+        export function read(name: string, bytes?: number): [string, number] | [null, string];
 
         /**
          * Removes a file or directory.
@@ -443,28 +434,11 @@ declare namespace love {
          * @param name The name (and path) of the file.
          * @param data The string data to write to the file.
          * @param size How many bytes to write.
-         * @return {boolean} success, If the operation was successful.
-         * @return {string} message, Error message if operation was unsuccessful.
+         * @returns _success_, If the operation was successful.
+         * @returns _message_, Error message if operation was unsuccessful.
+         * @tupleReturn
          */
-        /** @tupleReturn */
-        export function write(name: string, data: string, size?: number): [boolean, string];
-
-        /**
-         * Write data to a file.
-         *
-         *
-         * If you are getting the error message "Could not set write directory", try
-         * setting the save directory. This is done either with
-         * love.filesystem.setIdentity or by setting the identity field in love.conf.
-         *
-         * @param name The name (and path) of the file.
-         * @param data The Data object to write to the file.
-         * @param size How many bytes to write.
-         * @return {boolean} success, If the operation was successful.
-         * @return {string} message, Error message if operation was unsuccessful.
-         */
-        /** @tupleReturn */
-        export function write(name: string, data: Data, size?: number): [boolean, string];
+        export function write(name: string, data: Data | string, size?: number): [boolean, string];
 
     }
 

--- a/include/modules/filesystem/structs/FileInfo.d.ts
+++ b/include/modules/filesystem/structs/FileInfo.d.ts
@@ -9,13 +9,13 @@ declare type FileInfo = {
     type: FileType;
 
     /**
-     * The size in bytes of the file, or nil if it can't be determined.
+     * The size in bytes of the file, or _nil/null_ if it can't be determined.
      */
-    size?: number;
+    size: number | null;
 
     /**
-     * The file's last modification time in seconds since the unix epoch, or nil if it can't be determined.
+     * The file's last modification time in seconds since the unix epoch, or _nil/null_ if it can't be determined.
      */
-    modtime?: number;
+    modtime: number | null;
 
 };

--- a/include/modules/font/font_spec.ts
+++ b/include/modules/font/font_spec.ts
@@ -8,7 +8,7 @@ let bmFontRasterizer: BMFontRasterizer;
  * https://love2d.org/wiki/Font
  * Obtained 2019/03/02
  */
-let font: Font;
+declare const font: Font;
 font.getAscent;
 font.getBaseline;
 font.getDPIScale;
@@ -31,7 +31,7 @@ font.typeOf;
  * https://love2d.org/wiki/GlyphData
  * Obtained 2019/03/02
  */
-let glyphData: GlyphData;
+declare const glyphData: GlyphData;
 glyphData.clone;
 glyphData.getPointer;
 glyphData.getSize;
@@ -45,7 +45,7 @@ glyphData.typeOf;
  * https://love2d.org/wiki/Rasterizer
  * Obtained 2019/03/02
  */
-let rasterizer: Rasterizer;
+declare const rasterizer: Rasterizer;
 rasterizer.release;
 rasterizer.type;
 rasterizer.typeOf;

--- a/include/modules/graphics/graphics_spec.ts
+++ b/include/modules/graphics/graphics_spec.ts
@@ -6,7 +6,7 @@ let filterMode: FilterMode;
  * https://love2d.org/wiki/File
  * 2019/03/02
  */
-let canvas: Canvas;
+declare const canvas: Canvas;
 canvas.getMSAA;
 canvas.newImageData;
 canvas.renderTo;
@@ -40,7 +40,7 @@ canvas.setWrap;
  * https://love2d.org/wiki/Drawable
  * 2019/03/03
  */
-let drawable: Drawable;
+declare const drawable: Drawable;
 drawable.release;
 drawable.type;
 drawable.typeOf;
@@ -50,7 +50,7 @@ drawable.typeOf;
  * https://love2d.org/wiki/Image
  * 2019/03/03
  */
-let image: Image;
+declare const image: Image;
 image.getFlags;
 image.isCompressed;
 image.replacePixels;
@@ -84,7 +84,7 @@ image.setWrap;
  * https://love2d.org/wiki/Mesh
  * 2019/03/03
  */
-let mesh: Mesh;
+declare const mesh: Mesh;
 mesh.attachAttribute;
 mesh.detachAttribute;
 mesh.flush;
@@ -114,7 +114,7 @@ mesh.typeOf;
  * https://love2d.org/wiki/ParticleSystem
  * 2019/03/03
  */
-let particleSystem: ParticleSystem;
+declare const particleSystem: ParticleSystem;
 particleSystem.release;
 particleSystem.type;
 particleSystem.typeOf;
@@ -186,7 +186,7 @@ particleSystem.update;
  * https://love2d.org/wiki/Quad
  * 2019/03/03
  */
-let quad: Quad;
+declare const quad: Quad;
 quad.release;
 quad.type;
 quad.typeOf;
@@ -199,7 +199,7 @@ quad.setViewport;
  * https://love2d.org/wiki/Shader
  * 2019/03/03
  */
-let shader: Shader;
+declare const shader: Shader;
 shader.release;
 shader.type;
 shader.typeOf;
@@ -213,7 +213,7 @@ shader.sendColor;
  * https://love2d.org/wiki/SpriteBatch
  * 2019/03/03
  */
-let spriteBatch: SpriteBatch;
+declare const spriteBatch: SpriteBatch;
 spriteBatch.release;
 spriteBatch.type;
 spriteBatch.typeOf;
@@ -237,7 +237,7 @@ spriteBatch.setTexture;
  * https://love2d.org/wiki/Text
  * 2019/03/03
  */
-let text: Text;
+declare const text: Text;
 text.release;
 text.type;
 text.typeOf;
@@ -257,7 +257,7 @@ text.setf;
  * https://love2d.org/wiki/Texture
  * 2019/03/02
  */
-let texture: Texture;
+declare const texture: Texture;
 texture.getDPIScale;
 texture.getDepth;
 texture.getDepthSampleMode;
@@ -285,7 +285,7 @@ texture.setWrap;
  * https://love2d.org/wiki/Video
  * 2019/03/03
  */
-let video: Video;
+declare const video: Video;
 video.release;
 video.type;
 video.typeOf;

--- a/include/modules/graphics/love.graphics.d.ts
+++ b/include/modules/graphics/love.graphics.d.ts
@@ -469,9 +469,9 @@ declare namespace love {
         /**
          * Gets the current target Canvas.
          *
-         * @return {Canvas} canvas, The Canvas set by setCanvas. Returns nil if drawing to the real screen.
+         * @return canvas, The Canvas set by setCanvas. Returns _nil/null_ if drawing to the real screen.
          */
-        export function getCanvas(): Canvas;
+        export function getCanvas(): Canvas | null;
 
         /**
          * Gets the available Canvas formats, and whether each is supported.
@@ -559,9 +559,10 @@ declare namespace love {
         /**
          * Gets the current Font object.
          *
-         * @return {Font} font, The current Font, or nil if none is set.
+         * @return font, The current Font, or _nil/null_ if none is set.
+         * @link [love.graphics.getFont](https://love2d.org/wiki/love.graphics.getFont)
          */
-        export function getFont(): Font;
+        export function getFont(): Font | null;
 
         /**
          * Gets whether triangles with clockwise- or counterclockwise-ordered vertices are
@@ -639,11 +640,13 @@ declare namespace love {
         export function getMeshCullMode(): CullMode;
 
         /**
-         * Returns the current Shader. Returns nil if none is set.
+         * Returns the current Shader. Returns _nil/null_ if none is set.
          *
-         * @return {Shader} shader, The current Shader.
+         * @return shader, The current Shader.
+         * @link [love.graphics.getShader](https://love2d.org/wiki/love.graphics.getShader)
+         * @since 0.9.0
          */
-        export function getShader(): Shader;
+        export function getShader(): Shader | null;
 
         /**
          * Gets the current depth of the transform / state stack (the number of pushes
@@ -1131,10 +1134,12 @@ declare namespace love {
          * Creates a new drawable Text object.
          *
          * @param font The font to use for the text.
-         * @param textstring The initial string of text that the new Text object will contain. May be nil.
-         * @return {Text} text, The new drawable Text object.
+         * @param textstring The initial string of text that the new Text object will contain. May be _nil/null_.
+         * @return text, The new drawable Text object.
+         * @link [love.graphics.newText](https://love2d.org/wiki/love.graphics.newText)
+         * @since 0.10.0
          */
-        export function newText(font: Font, textstring?: string): Text;
+        export function newText(font: Font, textstring?: string): Text | null;
 
         /**
          * Creates a new Quad.
@@ -1874,11 +1879,13 @@ love.graphics.polygon("fill", ...vertexes);
          *
          * @param gles Validate code as GLSL ES shader.
          * @param code The pixel shader or vertex shader code, or a filename pointing to a file with the code.
-         * @return {boolean} status, true if specified shader code doesn't contain any errors. false otherwise.
-         * @return {string} message, Reason why shader code validation failed (or nil if validation succeded).
+         * @return status, true if specified shader code doesn't contain any errors. false otherwise.
+         * @return message, Reason why shader code validation failed (or _nil/null_ if validation succeded).
+         * @tupleReturn
+         * @link [love.graphics.validateShader](https://love2d.org/wiki/love.graphics.validateShader)
+         * @since 11.0
          */
-        /** @tupleReturn */
-        export function validateShader(gles: boolean, code: string): [boolean, string];
+        export function validateShader(gles: boolean, code: string): [true, null] | [false, string];
 
         /**
          * Validates shader code. Check if specificed shader code does not contain any
@@ -1887,11 +1894,13 @@ love.graphics.polygon("fill", ...vertexes);
          * @param gles Validate code as GLSL ES shader.
          * @param pixelcode The pixel shader code, or a filename pointing to a file with the code.
          * @param vertexcode The vertex shader code, or a filename pointing to a file with the code.
-         * @return {boolean} status, true if specified shader code doesn't contain any errors. false otherwise.
-         * @return {string} message, Reason why shader code validation failed (or nil if validation succeded).
+         * @return status, true if specified shader code doesn't contain any errors. false otherwise.
+         * @return message, Reason why shader code validation failed (or _nil/null_ if validation succeded).
+         * @tupleReturn
+         * @link [love.graphics.validateShader](https://love2d.org/wiki/love.graphics.validateShader)
+         * @since 11.0
          */
-        /** @tupleReturn */
-        export function validateShader(gles: boolean, pixelcode: string, vertexcode: string): [boolean, string];
+        export function validateShader(gles: boolean, pixelcode: string, vertexcode: string): [true, null] | [false, string];
 
     }
 

--- a/include/modules/graphics/types/Image.d.ts
+++ b/include/modules/graphics/types/Image.d.ts
@@ -69,10 +69,10 @@ declare interface Image extends Texture {
     /**
      * Gets the mipmap filter mode for an Image.
      *
-     * @return {FilterMode} mode, The filter mode used in between mipmap levels. nil if mipmap filtering is not enabled.
+     * @return {FilterMode} mode, The filter mode used in between mipmap levels. _nil/null_ if mipmap filtering is not enabled.
      * @return {number} sharpness, Value used to determine whether the image should use more or less detailed mipmap levels than normal when drawing.
+     * @tupleReturn
      */
-    /** @tupleReturn */
     getMipmapFilter(): [FilterMode, number];
 
     /**

--- a/include/modules/graphics/types/Mesh.d.ts
+++ b/include/modules/graphics/types/Mesh.d.ts
@@ -39,20 +39,22 @@ declare interface Mesh extends Drawable {
      *
      *
      * If the Mesh's draw range has not been set previously with Mesh:setDrawRange,
-     * this function will return nil.
+     * this function will return _nil/null_.
      *
-     * @return {number} min, The index of the first vertex used when drawing, or the index of the first value in the vertex map used if one is set for this Mesh.
-     * @return {number} max, The index of the last vertex used when drawing, or the index of the last value in the vertex map used if one is set for this Mesh.
+     * @return min, The index of the first vertex used when drawing, or the index of the first value in the vertex map used if one is set for this Mesh.
+     * @return max, The index of the last vertex used when drawing, or the index of the last value in the vertex map used if one is set for this Mesh.
+     * @tupleReturn
+     * @link [Mesh:getDrawRange](https://love2d.org/wiki/Mesh:getDrawRange)
      */
-    /** @tupleReturn */
-    getDrawRange(): [number, number];
+    getDrawRange(): [number | null, number | null];
 
     /**
      * Gets the texture (Image or Canvas) used when drawing the Mesh.
      *
-     * @return {Texture} texture, The Image or Canvas to texture the Mesh with when drawing, or nil if none is set.
+     * @return texture, The Image or Canvas to texture the Mesh with when drawing, or _nil/null_ if none is set.
+     * @link [Mesh:getTexture](https://love2d.org/wiki/Mesh:getTexture)
      */
-    getTexture(): Texture;
+    getTexture(): Texture | null;
 
     /**
      * Gets the properties of a vertex in the Mesh.
@@ -119,12 +121,13 @@ declare interface Mesh extends Drawable {
      *
      *
      * If no vertex map has been set previously via Mesh:setVertexMap, then this
-     * function will return nil in LÖVE 0.10.0+, or an empty table in 0.9.2 and
+     * function will return _nil/null_ in LÖVE 0.10.0+, or an empty table in 0.9.2 and
      * older.
      *
      * @return {table} map, A table containing a list of vertex indices used when drawing.
+     * @link [Mesh:getVertexMap](https://love2d.org/wiki/Mesh:getVertexMap)
      */
-    getVertexMap(): table;
+    getVertexMap(): table | null;
 
     /**
      * Gets whether a specific vertex attribute in the Mesh is enabled. Vertex data

--- a/include/modules/graphics/types/SpriteBatch.d.ts
+++ b/include/modules/graphics/types/SpriteBatch.d.ts
@@ -134,15 +134,16 @@ declare interface SpriteBatch extends Drawable {
      *
      *
      * If no color has been set with SpriteBatch:setColor or the current SpriteBatch
-     * color has been cleared, this method will return nil.
+     * color has been cleared, this method will return _nil/null_.
      *
      * @return {number} r, The red component (0-255).
      * @return {number} g, The green component (0-255).
      * @return {number} b, The blue component (0-255).
      * @return {number} a, The alpha component (0-255).
+     * @tupleReturn
+     * @link [SpriteBatch:getColor](https://love2d.org/wiki/SpriteBatch:getColor)
      */
-    /** @tupleReturn */
-    getColor(): [number, number, number, number];
+    getColor(): [number, number, number, number] | [null, null, null, null];
 
     /**
      * Gets the amount of sprites currently in the SpriteBatch.

--- a/include/modules/graphics/types/Texture.d.ts
+++ b/include/modules/graphics/types/Texture.d.ts
@@ -25,10 +25,10 @@ declare interface Texture extends Drawable {
 
     /**
      * Gets the comparison mode used when sampling from a depth texture in a shader.
-     * @return {CompareMode} compare, The comparison mode used when sampling from this texture in a shader, or nil if setDepthSampleMode has not been called on this Texture.
+     * @return {CompareMode} compare, The comparison mode used when sampling from this texture in a shader, or _nil/null_ if setDepthSampleMode has not been called on this Texture.
      * @link [Texture:getDepthSampleMode](https://love2d.org/wiki/Texture:getDepthSampleMode)
      */
-    getDepthSampleMode(): CompareMode;
+    getDepthSampleMode(): CompareMode | null;
 
     /**
      * Gets the width and height of the Texture.

--- a/include/modules/graphics/types/Video.d.ts
+++ b/include/modules/graphics/types/Video.d.ts
@@ -30,12 +30,13 @@ declare interface Video extends Drawable {
     getHeight(): number;
 
     /**
-     * Gets the audio Source used for playing back the video's audio. May return nil
-     * if the video has no audio, or if Video:setSource is called with a nil argument.
+     * Gets the audio Source used for playing back the video's audio. May return _nil/null_
+     * if the video has no audio, or if Video:setSource is called with a _nil/null_ argument.
      *
-     * @return {Source} source, The audio Source used for audio playback, or nil if the video has no audio.
+     * @return source, The audio Source used for audio playback, or _nil/null_ if the video has no audio.
+     * @link [Video:getSource](https://love2d.org/wiki/Video:getSource)
      */
-    getSource(): Source;
+    getSource(): Source | null;
 
     /**
      * Gets the VideoStream object used for decoding and controlling the video.
@@ -97,7 +98,8 @@ declare interface Video extends Drawable {
      * Sets the audio Source used for playing back the video's audio. The audio Source
      * also controls playback speed and synchronization.
      *
-     * @param source The audio Source used for audio playback, or nil to disable audio synchronization.
+     * @param source The audio Source used for audio playback. Leave blank to disable audio synchronization.
+     * @link [Video:setSource](https://love2d.org/wiki/Video:setSource)
      */
     setSource(source?: Source): void;
 

--- a/include/modules/image/image_spec.ts
+++ b/include/modules/image/image_spec.ts
@@ -3,7 +3,7 @@
  * https://love2d.org/wiki/CompressedImageData
  * 2019/03/03
  */
-let compressedImageData: CompressedImageData;
+declare const compressedImageData: CompressedImageData;
 compressedImageData.getDimensions;
 compressedImageData.getFormat;
 compressedImageData.getHeight;
@@ -22,7 +22,7 @@ compressedImageData.typeOf;
  * https://love2d.org/wiki/ImageData
  * Obtained 2019/03/02
  */
-let imageData: ImageData;
+declare const imageData: ImageData;
 imageData.clone;
 imageData.getPointer;
 imageData.getSize;
@@ -40,7 +40,7 @@ imageData.release;
 imageData.type;
 imageData.typeOf;
 
-let c: CompressedImageData;
+declare const c: CompressedImageData;
 
 love;
 love.image;

--- a/include/modules/image/types/ImageData.d.ts
+++ b/include/modules/image/types/ImageData.d.ts
@@ -7,8 +7,9 @@ declare interface ImageData extends Data {
      * Encodes the ImageData and optionally writes it to the save directory.
      *
      * @param format The format to encode the image as.
-     * @param filename The filename to write the file to. If nil, no file will be written but the FileData will still be returned.
-     * @return {FileData} filedata, The encoded image as a new FileData object.
+     * @param filename The filename to write the file to. If unspecified, no file will be written but the FileData will still be returned.
+     * @return filedata, The encoded image as a new FileData object.
+     * @link [ImageData:encode](https://love2d.org/wiki/ImageData:encode)
      */
     encode(format: ImageFormat, filename?: string): FileData;
 
@@ -22,10 +23,10 @@ declare interface ImageData extends Data {
     getDimensions(): [number, number];
 
     /**
-     * TODO description
-     * @param TODO
-     * @return {return_type} desc, description
+     * Gets the pixel format of the ImageData.
+     * @return format, The pixel format the ImageData was created with.
      * @link [ImageData:getFormat](https://love2d.org/wiki/ImageData:getFormat)
+     * @since 11.0
      */
     getFormat(): PixelFormat;
 

--- a/include/modules/joystick/joystick_spec.ts
+++ b/include/modules/joystick/joystick_spec.ts
@@ -3,7 +3,7 @@
  * https://love2d.org/wiki/Joystick
  * Obtained 2019/03/03
  */
-let joystick: Joystick;
+declare const joystick: Joystick;
 joystick.getAxes;
 joystick.getAxis;
 joystick.getAxisCount;

--- a/include/modules/joystick/love.joystick.d.ts
+++ b/include/modules/joystick/love.joystick.d.ts
@@ -75,10 +75,10 @@ declare namespace love {
          * @param button The virtual gamepad button to bind.
          * @param inputtype The type of input to bind the virtual gamepad button to.
          * @param inputindex The index of the axis, button, or hat to bind the virtual gamepad button to.
-         * @param hatdirection The direction of the hat, if the virtual gamepad button will be bound to a hat. nil otherwise.
+         * @param hatdirection The direction of the hat, if the virtual gamepad button will be bound to a hat. Unspecified otherwise.
          * @return {boolean} success, Whether the virtual gamepad button was successfully bound.
          */
-        export function setGamepadMapping(guid: string, button: GamepadButton, inputtype: JoystickInputType, inputindex: number, hatdirection: JoystickHat): boolean;
+        export function setGamepadMapping(guid: string, button: GamepadButton, inputtype: JoystickInputType, inputindex: number, hatdirection?: JoystickHat): boolean;
 
         /**
          * Binds a virtual gamepad input to a button, axis or hat for all Joysticks of a
@@ -100,10 +100,10 @@ declare namespace love {
          * @param axis The virtual gamepad axis to bind.
          * @param inputtype The type of input to bind the virtual gamepad axis to.
          * @param inputindex The index of the axis, button, or hat to bind the virtual gamepad axis to.
-         * @param hatdirection The direction of the hat, if the virtual gamepad axis will be bound to a hat. nil otherwise.
+         * @param hatdirection The direction of the hat, if the virtual gamepad axis will be bound to a hat. Unspecified otherwise.
          * @return {boolean} success, Whether the virtual gamepad button was successfully bound.
          */
-        export function setGamepadMapping(guid: string, axis: GamepadAxis, inputtype: JoystickInputType, inputindex: number, hatdirection: JoystickHat): boolean;
+        export function setGamepadMapping(guid: string, axis: GamepadAxis, inputtype: JoystickInputType, inputindex: number, hatdirection?: JoystickHat): boolean;
 
     }
 

--- a/include/modules/joystick/types/Joystick.d.ts
+++ b/include/modules/joystick/types/Joystick.d.ts
@@ -56,24 +56,13 @@ declare interface Joystick extends Object {
     /**
      * Gets the button, axis or hat that a virtual gamepad input is bound to.
      *
-     * @param axis The virtual gamepad axis to get the binding for.
+     * @param axisOrButton The virtual gamepad axis or button to get the binding for.
      * @return {JoystickInputType} inputtype, The type of input the virtual gamepad axis is bound to.
      * @return {number} inputindex, The index of the Joystick's button, axis or hat that the virtual gamepad axis is bound to.
-     * @return {JoystickHat} hatdirection, The direction of the hat, if the virtual gamepad axis is bound to a hat. nil otherwise.
+     * @return {JoystickHat} hatdirection, The direction of the hat, if the virtual gamepad axis is bound to a hat. _nil/null_ otherwise.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    getGamepadMapping(axis: GamepadAxis): [JoystickInputType, number, JoystickHat];
-
-    /**
-     * Gets the button, axis or hat that a virtual gamepad input is bound to.
-     *
-     * @param button The virtual gamepad button to get the binding for.
-     * @return {JoystickInputType} inputtype, The type of input the virtual gamepad button is bound to.
-     * @return {number} inputindex, The index of the Joystick's button, axis or hat that the virtual gamepad button is bound to.
-     * @return {JoystickHat} hatdirection, The direction of the hat, if the virtual gamepad button is bound to a hat. nil otherwise.
-     */
-    /** @tupleReturn */
-    getGamepadMapping(button: GamepadAxis): [JoystickInputType, number, JoystickHat];
+    getGamepadMapping(axisOrButton: GamepadAxis | GamepadButton): [JoystickInputType, number, JoystickHat | null];
 
     /**
      * Gets the direction of the Joystick's hat.
@@ -96,10 +85,10 @@ declare interface Joystick extends Object {
      * but it will change when the game is re-launched.
      *
      * @return {number} id, The Joystick's unique identifier. Remains the same as long as the game is running.
-     * @return {number} instanceid, Unique instance identifier. Changes every time the Joystick is reconnected. nil if the Joystick is not connected.
+     * @return {number} instanceid, Unique instance identifier. Changes every time the Joystick is reconnected. _nil/null_ if the Joystick is not connected.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    getID(): [number, number];
+    getID(): [number, number | null];
 
     /**
      * Gets the name of the joystick.

--- a/include/modules/math/math_spec.ts
+++ b/include/modules/math/math_spec.ts
@@ -3,7 +3,7 @@
  * https://love2d.org/wiki/BezierCurve
  * Obtained 2019/03/03
  */
-let bezierCurve: BezierCurve;
+declare const bezierCurve: BezierCurve;
 bezierCurve.evaluate;
 bezierCurve.getControlPoint;
 bezierCurve.getControlPointCount;
@@ -27,7 +27,7 @@ bezierCurve.typeOf;
  * https://love2d.org/wiki/CompressedData
  * Obtained 2019/03/02
  */
-let compressedData: CompressedData;
+declare const compressedData: CompressedData;
 compressedData.getFormat;
 compressedData.clone;
 compressedData.getPointer;
@@ -42,7 +42,7 @@ compressedData.typeOf;
  * https://love2d.org/wiki/RandomGenerator
  * Obtained 2019/03/03
  */
-let randomGenerator: RandomGenerator;
+declare const randomGenerator: RandomGenerator;
 randomGenerator.release;
 randomGenerator.type;
 randomGenerator.typeOf;
@@ -58,7 +58,7 @@ randomGenerator.setState;
  * https://love2d.org/wiki/Transform
  * 2019/03/03
  */
-let transform: Transform;
+declare const transform: Transform;
 transform.release;
 transform.type;
 transform.typeOf;

--- a/include/modules/mouse/love.mouse.d.ts
+++ b/include/modules/mouse/love.mouse.d.ts
@@ -9,9 +9,10 @@ declare namespace love {
         /**
          * Gets the current Cursor.
          *
-         * @return {Cursor} cursor, The current cursor, or nil if no cursor is set.
+         * @return cursor, The current cursor, or _nil/null_ if no cursor is set.
+         * [love.mouse.getCursor](https://love2d.org/wiki/love.mouse.getCursor)
          */
-        export function getCursor(): Cursor;
+        export function getCursor(): Cursor | null;
 
         /**
          * Returns the current position of the mouse.

--- a/include/modules/physics/physics_spec.ts
+++ b/include/modules/physics/physics_spec.ts
@@ -3,7 +3,7 @@
  * https://love2d.org/wiki/Body
  * Obtained 2019/03/03
  */
-let body: Body;
+declare const body: Body;
 body.applyAngularImpulse;
 body.applyForce;
 body.applyLinearImpulse;
@@ -72,7 +72,7 @@ body.typeOf;
  * https://love2d.org/wiki/ChainShape
  * Obtained 2019/03/03
  */
-let chainShape: ChainShape;
+declare const chainShape: ChainShape;
 chainShape.getChildEdge;
 chainShape.getNextVertex;
 chainShape.getPoint;
@@ -97,7 +97,7 @@ chainShape.testPoint;
  * https://love2d.org/wiki/CircleShape
  * Obtained 2019/03/03
  */
-let circleShape: CircleShape;
+declare const circleShape: CircleShape;
 circleShape.getPoint;
 circleShape.getRadius;
 circleShape.setPoint;
@@ -118,7 +118,7 @@ circleShape.testPoint;
  * https://love2d.org/wiki/Contact
  * Obtained 2019/04/03
  */
-let contact: Contact;
+declare const contact: Contact;
 contact.getChildren;
 contact.getFixtures;
 contact.getFriction;
@@ -138,7 +138,7 @@ contact.setRestitution;
  * https://love2d.org/wiki/DistanceJoint
  * Obtained 2019/03/03
  */
-let distanceJoint: DistanceJoint;
+declare const distanceJoint: DistanceJoint;
 distanceJoint.getDampingRatio;
 distanceJoint.getFrequency;
 distanceJoint.getLength;
@@ -161,7 +161,7 @@ distanceJoint.setUserData;
  * https://love2d.org/wiki/EdgeShape
  * Obtained 2019/03/03
  */
-let edgeShape: EdgeShape;
+declare const edgeShape: EdgeShape;
 edgeShape.getNextVertex;
 edgeShape.getPoints;
 edgeShape.getPreviousVertex;
@@ -183,7 +183,7 @@ edgeShape.testPoint;
  * https://love2d.org/wiki/Fixture
  * Obtained 2019/03/03
  */
-let fixture: Fixture;
+declare const fixture: Fixture;
 fixture.destroy;
 fixture.getBody;
 fixture.getBoundingBox;
@@ -219,7 +219,7 @@ fixture.typeOf;
  * https://love2d.org/wiki/FrictionJoint
  * Obtained 2019/03/03
  */
-let frictionJoint: FrictionJoint;
+declare const frictionJoint: FrictionJoint;
 frictionJoint.getMaxForce;
 frictionJoint.getMaxTorque;
 frictionJoint.setMaxForce;
@@ -240,7 +240,7 @@ frictionJoint.setUserData;
  * https://love2d.org/wiki/GearJoint
  * Obtained 2019/03/03
  */
-let gearJoint: GearJoint;
+declare const gearJoint: GearJoint;
 gearJoint.getJoints;
 gearJoint.getRatio;
 gearJoint.setRatio;
@@ -260,7 +260,7 @@ gearJoint.setUserData;
  * https://love2d.org/wiki/Joint
  * Obtained 2019/03/03
  */
-let joint: Joint;
+declare const joint: Joint;
 joint.destroy;
 joint.getAnchors;
 joint.getBodies;
@@ -280,7 +280,7 @@ joint.typeOf;
  * https://love2d.org/wiki/MouseJoint
  * Obtained 2019/03/03
  */
-let mouseJoint: MouseJoint;
+declare const mouseJoint: MouseJoint;
 mouseJoint.destroy;
 mouseJoint.getAnchors;
 mouseJoint.getBodies;
@@ -305,7 +305,7 @@ mouseJoint.setTarget;
  * https://love2d.org/wiki/PolygonShape
  * Obtained 2019/03/03
  */
-let polygonShape: PolygonShape;
+declare const polygonShape: PolygonShape;
 polygonShape.release;
 polygonShape.type;
 polygonShape.typeOf;
@@ -324,7 +324,7 @@ polygonShape.testPoint;
  * https://love2d.org/wiki/PulleyJoint
  * Obtained 2019/03/03
  */
-let pulleyJoint: PulleyJoint;
+declare const pulleyJoint: PulleyJoint;
 pulleyJoint.destroy;
 pulleyJoint.getAnchors;
 pulleyJoint.getBodies;
@@ -350,7 +350,7 @@ pulleyJoint.setRatio;
  * https://love2d.org/wiki/RevoluteJoint
  * Obtained 2019/03/03
  */
-let revoluteJoint: RevoluteJoint;
+declare const revoluteJoint: RevoluteJoint;
 revoluteJoint.destroy;
 revoluteJoint.getAnchors;
 revoluteJoint.getBodies;
@@ -384,7 +384,7 @@ revoluteJoint.setMotorSpeed;
  * https://love2d.org/wiki/RopeJoint
  * Obtained 2019/03/03
  */
-let ropeJoint: RopeJoint;
+declare const ropeJoint: RopeJoint;
 ropeJoint.destroy;
 ropeJoint.getAnchors;
 ropeJoint.getBodies;
@@ -403,7 +403,7 @@ ropeJoint.setMaxLength;
  * https://love2d.org/wiki/PrismaticJoint
  * Obtained 2019/03/03
  */
-let prismaticJoint: PrismaticJoint;
+declare const prismaticJoint: PrismaticJoint;
 prismaticJoint.destroy;
 prismaticJoint.getAnchors;
 prismaticJoint.getBodies;
@@ -439,7 +439,7 @@ prismaticJoint.setUpperLimit;
  * https://love2d.org/wiki/MotorJoint
  * Obtained 2019/03/03
  */
-let motorJoint: MotorJoint;
+declare const motorJoint: MotorJoint;
 motorJoint.destroy;
 motorJoint.getAnchors;
 motorJoint.getBodies;
@@ -460,7 +460,7 @@ motorJoint.setLinearOffset;
  * https://love2d.org/wiki/Shape
  * Obtained 2019/03/03
  */
-let shape: Shape;
+declare const shape: Shape;
 shape.release;
 shape.type;
 shape.typeOf;
@@ -477,7 +477,7 @@ shape.testPoint;
  * https://love2d.org/wiki/WeldJoint
  * Obtained 2019/03/03
  */
-let weldJoint: WeldJoint;
+declare const weldJoint: WeldJoint;
 weldJoint.destroy;
 weldJoint.getAnchors;
 weldJoint.getBodies;
@@ -498,7 +498,7 @@ weldJoint.setFrequency;
  * https://love2d.org/wiki/WheelJoint
  * Obtained 2019/03/03
  */
-let wheelJoint: WheelJoint;
+declare const wheelJoint: WheelJoint;
 wheelJoint.destroy;
 wheelJoint.getAnchors;
 wheelJoint.getBodies;
@@ -529,7 +529,7 @@ wheelJoint.setSpringFrequency;
  * https://love2d.org/wiki/World
  * Obtained 2019/03/03
  */
-let world: World;
+declare const world: World;
 world.release;
 world.type;
 world.typeOf;

--- a/include/modules/physics/types/Body.d.ts
+++ b/include/modules/physics/types/Body.d.ts
@@ -732,7 +732,7 @@ declare interface Body extends Object {
      * Associates a Lua value with the Body.
      *
      *
-     * To delete the reference, explicitly pass nil.
+     * To delete the reference, explicitly pass _nil/null_.
      *
      * @param value The Lua value to associate with the Body.
      */

--- a/include/modules/physics/types/ChainShape.d.ts
+++ b/include/modules/physics/types/ChainShape.d.ts
@@ -23,8 +23,8 @@ declare interface ChainShape extends Shape {
      * collisions when a flat shape slides along the edge and moves over to the new
      * shape.
      *
-     * @param x The x-component of the vertex, or nil if ChainShape:setNextVertex hasn't been called.
-     * @param y The y-component of the vertex, or nil if ChainShape:setNextVertex hasn't been called.
+     * @param x The x-component of the vertex, or _nil/null/undefined_ if ChainShape:setNextVertex hasn't been called.
+     * @param y The y-component of the vertex, or _nil/null/undefined_ if ChainShape:setNextVertex hasn't been called.
      */
     getNextVertex(x?: number, y?: number): void;
 
@@ -58,11 +58,11 @@ declare interface ChainShape extends Shape {
      * collisions when a flat shape slides along the edge and moves over to the new
      * shape.
      *
-     * @return {number} x, The x-component of the vertex, or nil if ChainShape:setNextVertex hasn't been called.
-     * @return {number} y, The y-component of the vertex, or nil if ChainShape:setNextVertex hasn't been called.
+     * @return {number} x, The x-component of the vertex, or _nil/null_ if ChainShape:setNextVertex hasn't been called.
+     * @return {number} y, The y-component of the vertex, or _nil/null_ if ChainShape:setNextVertex hasn't been called.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    getPreviousVertex(): [number, number];
+    getPreviousVertex(): [number, number] | [null, null];
 
     /**
      * Returns the number of vertices the shape has.

--- a/include/modules/physics/types/EdgeShape.d.ts
+++ b/include/modules/physics/types/EdgeShape.d.ts
@@ -26,11 +26,11 @@ declare interface EdgeShape extends Shape {
      * collisions when a flat shape slides along the edge and moves over to the new
      * shape.
      *
-     * @return {number} x, The x-component of the vertex, or nil if EdgeShape:setNextVertex hasn't been called.
-     * @return {number} y, The y-component of the vertex, or nil if EdgeShape:setNextVertex hasn't been called.
+     * @return {number} x, The x-component of the vertex, or _nil/null_ if EdgeShape:setNextVertex hasn't been called.
+     * @return {number} y, The y-component of the vertex, or _nil/null_ if EdgeShape:setNextVertex hasn't been called.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    getNextVertex(): [number, number];
+    getNextVertex(): [number, number] | [null, null];
 
     /**
      * Gets the vertex that establishes a connection to the previous shape.
@@ -40,11 +40,11 @@ declare interface EdgeShape extends Shape {
      * collisions when a flat shape slides along the edge and moves over to the new
      * shape.
      *
-     * @return {number} x, The x-component of the vertex, or nil if EdgeShape:setPreviousVertex hasn't been called.
-     * @return {number} y, The y-component of the vertex, or nil if EdgeShape:setPreviousVertex hasn't been called.
+     * @return {number} x, The x-component of the vertex, or _nil/null_ if EdgeShape:setPreviousVertex hasn't been called.
+     * @return {number} y, The y-component of the vertex, or _nil/null_ if EdgeShape:setPreviousVertex hasn't been called.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    getPreviousVertex(): [number, number];
+    getPreviousVertex(): [number, number] | [null, null];
 
     /**
      * Sets a vertex that establishes a connection to the next shape.

--- a/include/modules/physics/types/Fixture.d.ts
+++ b/include/modules/physics/types/Fixture.d.ts
@@ -145,7 +145,7 @@ declare interface Fixture extends Object {
     /**
      * Casts a ray against the shape of the fixture and returns the surface normal
      * vector and the line position where the ray hit. If the ray missed the shape,
-     * nil will be returned.
+     * _nil/null_ will be returned.
      *
      *
      * The ray starts on the first point of the input line and goes towards the second
@@ -175,9 +175,9 @@ declare interface Fixture extends Object {
      * @return {number} x, The x position where the ray intersects with the shape.
      * @return {number} y, The y position where the ray intersects with the shape.
      * @return {number} fraction, The position on the input vector where the intersection happened as a number from 0 to 1.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    rayCast(x1: number, y1: number, x2: number, y2: number, maxFraction: number, childIndex?: number): [number, number, number];
+    rayCast(x1: number, y1: number, x2: number, y2: number, maxFraction: number, childIndex?: number): [number, number, number] | [null, null, null];
 
     /**
      * Sets the categories the fixture belongs to. There can be up to 16 categories

--- a/include/modules/physics/types/Joint.d.ts
+++ b/include/modules/physics/types/Joint.d.ts
@@ -81,7 +81,7 @@ declare interface Joint extends Object {
      * Associates a Lua value with the Joint.
      *
      *
-     * To delete the reference, explicitly pass nil.
+     * To delete the reference, explicitly pass _nil/null_.
      *
      * @param value The Lua value to associate with the Joint.
      */

--- a/include/modules/physics/types/Shape.d.ts
+++ b/include/modules/physics/types/Shape.d.ts
@@ -54,7 +54,7 @@ declare interface Shape extends Object {
 
     /**
      * Casts a ray against the shape and returns the surface normal vector and the
-     * line position where the ray hit. If the ray missed the shape, nil will be
+     * line position where the ray hit. If the ray missed the shape, _nil/null_ will be
      * returned. The Shape can be transformed to get it into the desired position.
      *
      *
@@ -88,9 +88,9 @@ declare interface Shape extends Object {
      * @return {number} xn, The x component of the normal vector of the edge where the ray hit the shape.
      * @return {number} yn, The y component of the normal vector of the edge where the ray hit the shape.
      * @return {number} fraction, The position on the input line where the intersection happened as a factor of the line length.
+     * @tupleReturn
      */
-    /** @tupleReturn */
-    rayCast(x1: number, y1: number, x2: number, y2: number, maxFraction: number, tx: number, ty: number, tr: number, childIndex?: number): [number, number, number];
+    rayCast(x1: number, y1: number, x2: number, y2: number, maxFraction: number, tx: number, ty: number, tr: number, childIndex?: number): [number, number, number] | [null, null, null];
 
     /**
      * Checks whether a point lies inside the shape. This is particularly useful for

--- a/include/modules/physics/types/World.d.ts
+++ b/include/modules/physics/types/World.d.ts
@@ -140,7 +140,7 @@ declare interface World extends Object {
      * Sets functions for the collision callbacks during the world update.
      *
      *
-     * Four Lua functions can be given as arguments. The value nil removes a function.
+     * Four Lua functions can be given as arguments. The value _nil/null/undefined_ removes a function.
      *
      *
      * When called, each function will be passed three arguments. The first two

--- a/include/modules/sound/sound_spec.ts
+++ b/include/modules/sound/sound_spec.ts
@@ -2,7 +2,7 @@
  * Documented at
  * https://love2d.org/wiki/Decoder
  */
-let decoder: Decoder;
+declare const decoder: Decoder;
 decoder.decode;
 decoder.getBitDepth;
 decoder.getChannelCount;
@@ -17,7 +17,7 @@ decoder.typeOf;
  * Documented at
  * https://love2d.org/wiki/SoundData
  */
-let soundData: SoundData;
+declare const soundData: SoundData;
 soundData.clone;
 soundData.getPointer;
 soundData.getSize;

--- a/include/modules/system/love.system.d.ts
+++ b/include/modules/system/love.system.d.ts
@@ -25,12 +25,12 @@ declare namespace love {
         /**
          * Gets information about the system's power supply.
          *
-         * @return {PowerState} state, The basic state of the power supply.
-         * @return {number} percent, Percentage of battery life left, between 0 and 100. nil if the value can't be determined or there's no battery.
-         * @return {number} seconds, Seconds of battery life left. nil if the value can't be determined or there's no battery.
+         * @return state, The basic state of the power supply.
+         * @return percent, Percentage of battery life left, between 0 and 100. _nil/null_ if the value can't be determined or there's no battery.
+         * @return seconds, Seconds of battery life left. _nil/null_ if the value can't be determined or there's no battery.
+         * @tupleReturn
          */
-        /** @tupleReturn */
-        export function getPowerInfo(): [PowerState, number, number];
+        export function getPowerInfo(): [PowerState, number | null, number | null];
 
         /**
          * Gets the amount of logical processor in the system.

--- a/include/modules/thread/thread_spec.ts
+++ b/include/modules/thread/thread_spec.ts
@@ -3,7 +3,7 @@
  * https://love2d.org/wiki/Channel
  * 2019/03/03
  */
-let channel: Channel;
+declare const channel: Channel;
 channel.clear;
 channel.demand;
 channel.getCount;
@@ -21,7 +21,7 @@ channel.typeOf;
  * Documented at
  * https://love2d.org/wiki/Thread
  */
-let thread: Thread;
+declare const thread: Thread;
 thread.release;
 thread.type;
 thread.typeOf;

--- a/include/modules/thread/types/Channel.d.ts
+++ b/include/modules/thread/types/Channel.d.ts
@@ -27,9 +27,9 @@ declare interface Channel extends Object {
      * It waits until a message is in the queue then returns the message value.
      *
      * @param timeout The maximum amount of time to wait.
-     * @return {any} value, The contents of the message or nil if the timeout expired.
+     * @return value, The contents of the message or _nil/null_ if the timeout expired.
      */
-    demand(timeout: number): any;
+    demand(timeout: number): any | null;
 
     /**
      * Retrieves the number of messages in the thread Channel queue.
@@ -51,11 +51,11 @@ declare interface Channel extends Object {
      * Retrieves the value of a Channel message, but leaves it in the queue.
      *
      *
-     * It returns nil if there's no message in the queue.
+     * It returns _nil/null_ if there's no message in the queue.
      *
-     * @return {any} value, The contents of the message.
+     * @return value, The contents of the message.
      */
-    peek(): any;
+    peek(): any | null;
 
     /**
      * Executes the specified function atomically with respect to this Channel.
@@ -83,11 +83,11 @@ declare interface Channel extends Object {
      * Retrieves the value of a Channel message and removes it from the message queue.
      *
      *
-     * It returns nil if there are no messages in the queue.
+     * It returns _nil/null_ if there are no messages in the queue.
      *
-     * @return {any} value, The contents of the message.
+     * @return value, The contents of the message.
      */
-    pop(): any;
+    pop(): any | null;
 
     /**
      * Send a message to the thread Channel.

--- a/include/modules/video/video_spec.ts
+++ b/include/modules/video/video_spec.ts
@@ -3,7 +3,7 @@
  * https://love2d.org/wiki/VideoStream
  * 2019/03/03
  */
-let videoStream: VideoStream;
+declare const videoStream: VideoStream;
 videoStream.release;
 videoStream.type;
 videoStream.typeOf;

--- a/include/modules/window/love.window.d.ts
+++ b/include/modules/window/love.window.d.ts
@@ -135,9 +135,9 @@ declare namespace love {
         /**
          * Gets the window icon.
          *
-         * @return {ImageData} imagedata, The window icon imagedata, or nil of no icon has been set with love.window.setIcon.
+         * @return imagedata, The window icon imagedata, or _nil/null_ of no icon has been set with love.window.setIcon.
          */
-        export function getIcon(): ImageData;
+        export function getIcon(): ImageData | null;
 
         /**
          * Returns the current display mode.

--- a/include/utf8.d.ts
+++ b/include/utf8.d.ts
@@ -11,6 +11,7 @@
  * sequence or one plus the length of the subject string. As in the string
  * library, negative indices count from the end of the string.
  * @noSelf
+ * @noResolution
  */
 declare module "utf8" {
   /**
@@ -59,12 +60,12 @@ declare module "utf8" {
    * i. The default for i is 1 when n is non-negative and #s + 1 otherwise, so that
    * utf8.offset(s, -n) gets the offset of the n-th character from the end of the
    * string. If the specified character is neither in the subject nor right after its
-   * end, the function returns nil.
+   * end, the function returns _nil/null_.
    *
    * As a special case, when n is 0 the function returns the start of the encoding
    * of the character that contains the i-th byte of s.
    *
    * This function assumes that s is a valid UTF-8 string.
    */
-  function offset(s: string, n?: number, i?: number): number;
+  function offset(s: string, n?: number, i?: number): number | null;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"rootDir": "include",
 		"lib": ["es6"],
-		"types": ["lua-types/jit"]
+		"types": ["lua-types/jit"],
+		"strictNullChecks": true
 	},
 	"include": [
 		"index.d.ts",


### PR DESCRIPTION
For increasing the effectiveness of the `--strictNullChecks` option.

If a value can be _null_ (or _nil_) TypeScript will make sure you're considering that possibility.

```ts
const settings = love.audio.getEffect("myEffect");
settings.type;      // Object is possibly 'null'
if (settings) {
    settings.type;  // settings cannot be null if the code made it here.
}
```

This can be specified in your `tsconfig.json` file.

```json
{
    "compilerOptions": {
        "strictNullChecks": true,
    }
}
```

`--strict` also enables this.

The following functions/properties now have to possibility of returning/being _null_:

- `love.audio.getEffect`
- `RecordingDevice#getData`
- `RecordingDevice#stop`
- `Source#getEffect`
- `Source#getFilter`
- `love.filesystem.getInfo`
- `love.filesystem.getLastModified`
- `love.filesystem.getSize`
- `love.filesystem.newFile`
- `love.filesystem.newFileData`
- `love.filesystem.read`
- `FileInfo#size`
- `FileInfo#modtime`
- `love.graphics.getCanvas`
- `love.graphics.getFont`
- `love.graphics.getShader`
- `love.graphics.newText`
- `love.graphics.validateShader`
- `Mesh#getDrawRange`
- `Mesh#getTexture`
- `Mesh#getVertexMap`
- `SpriteBatch#getColor`
- `Texture#getDepthSampleMode`
- `Video#getSource`
- `Joystick#getGamepadMapping`
- `Joystick#getID`
- `love.mouse.getCursor`
- `CircleShape#getPreviousVertex`
- `EdgeShape#getNextVertex`
- `EdgeShape#getPreviousVertex`
- `Fixture#raycast`
- `Shape#raycast`
- `love.system.getPowerInfo`
- `Channel#timeout`
- `Channel#peek`
- `Channel#pop`
- `love.window.getIcon`
- `utf8.offset`

Fixed `utf8` module with `@noResolution`.