### PR TITLE
Using union for effect types

### DIFF
--- a/include/modules/audio/audio_spec.ts
+++ b/include/modules/audio/audio_spec.ts
@@ -111,3 +111,18 @@ love.audio.setPosition;
 love.audio.setVelocity;
 love.audio.setVolume;
 love.audio.stop;
+
+// effect setting types
+const settings = love.audio.getEffect("effect");
+if (settings) {
+    switch (settings.type) {
+        case "chorus": settings.delay; break;
+        case "compressor": settings.enable; break;
+        case "distortion": settings.bandwidth; break;
+        case "echo": settings.damping; break;
+        case "equalizer": settings.highcut; break;
+        case "flanger": settings.delay; break;
+        case "reverb": settings.airabsorption; break;
+        case "ringmodulator": settings.frequency; break;
+    }
+}

--- a/include/modules/audio/structs/EffectSettings.d.ts
+++ b/include/modules/audio/structs/EffectSettings.d.ts
@@ -5,16 +5,21 @@
  * @link [love.audio.setEffect](https://love2d.org/wiki/love.audio.setEffect)
  * @link [love.audio.getEffect](https://love2d.org/wiki/love.audio.getEffect)
  */
-interface EffectSettings {
-    type: EffectType;
-}
+declare type EffectSettings = ChorusEffectSettings
+    | CompressorEffectSettings
+    | DistortionEffectSettings
+    | EchoEffectSettings
+    | EqualizerEffectSettings
+    | FlangerEffectSettings
+    | ReverbEffectSettings
+    | RingModulatorEffectSettings;
 
 /**
  * Plays multiple copies of the sound with slight pitch and time variation.
  *
  * Used to make sounds sound "fuller" or "thicker".
  */
-interface ChorusEffectSettings extends EffectSettings {
+interface ChorusEffectSettings {
     type: "chorus";
     waveform?: EffectWaveform;
     phase?: number;
@@ -27,7 +32,7 @@ interface ChorusEffectSettings extends EffectSettings {
 /**
  * Decreases the dynamic range of the sound, making the loud and quiet parts closer in volume, producing a more uniform amplitude throughout time.
  */
-interface CompressorEffectSettings extends EffectSettings {
+interface CompressorEffectSettings {
     type: "compressor";
     enable?: boolean;
 }
@@ -35,7 +40,7 @@ interface CompressorEffectSettings extends EffectSettings {
 /**
  * Alters the sound by amplifying it until it clips, shearing off parts of the signal, leading to a compressed and distorted sound.
  */
-interface DistortionEffectSettings extends EffectSettings {
+interface DistortionEffectSettings {
     type: "distortion";
     gain?: number;
     edge?: number;
@@ -49,7 +54,7 @@ interface DistortionEffectSettings extends EffectSettings {
  *
  * Also known as delay; causes the sound to repeat at regular intervals at a decreasing volume.
  */
-interface EchoEffectSettings extends EffectSettings {
+interface EchoEffectSettings {
     type: "echo";
     delay?: number;
     tapdelay?: number;
@@ -61,7 +66,7 @@ interface EchoEffectSettings extends EffectSettings {
 /**
  * Adjust the frequency components of the sound using a 4-band (low-shelf, two band-pass and a high-shelf) equalizer.
  */
-interface EqualizerEffectSettings extends EffectSettings {
+interface EqualizerEffectSettings {
     type: "equalizer";
     lowgain?: number;
     lowcut?: number;
@@ -78,7 +83,7 @@ interface EqualizerEffectSettings extends EffectSettings {
 /**
  * Plays two copies of the sound; while varying the phase, or equivalently delaying one of them, by amounts on the order of milliseconds, resulting in phasing sounds.
  */
-interface FlangerEffectSettings extends EffectSettings {
+interface FlangerEffectSettings {
     type: "flanger";
     phase?: number;
     rate?: number;
@@ -92,7 +97,7 @@ interface FlangerEffectSettings extends EffectSettings {
  *
  * Used to simulate the reflection off of the surroundings.
  */
-interface ReverbEffectSettings extends EffectSettings {
+interface ReverbEffectSettings {
     type: "reverb";
     gain?: number;
     highgain?: number;
@@ -112,7 +117,7 @@ interface ReverbEffectSettings extends EffectSettings {
 /**
  * An implementation of amplitude modulation; multiplies the source signal with a simple waveform, to produce either volume changes, or inharmonic overtones.
  */
-interface RingModulatorEffectSettings extends EffectSettings {
+interface RingModulatorEffectSettings {
     type: "ringmodulator";
     waveform?: EffectWaveform;
     frequency?: number;


### PR DESCRIPTION
Made it possible to do this:

```ts
// effect setting types
const settings = love.audio.getEffect("effect");
if (settings) {
    switch (settings.type) {
        case "chorus": settings.delay; break;
        case "compressor": settings.enable; break;
        case "distortion": settings.bandwidth; break;
        case "echo": settings.damping; break;
        case "equalizer": settings.highcut; break;
        case "flanger": settings.delay; break;
        case "reverb": settings.airabsorption; break;
        case "ringmodulator": settings.frequency; break;
    }
}
```

If TypeScript knows that the `type` of a setting is `"chorus"` it figures out, automatically, that these are Chorus effect settings and make sure you use its properties correctly.