### PR TITLE
Adds extention and default value for shader functions

### DIFF
--- a/typings/love.graphics/functions.d.ts
+++ b/typings/love.graphics/functions.d.ts
@@ -1307,7 +1307,7 @@ declare module "love.graphics" {
      * @link [love.graphics.newShader](https://love2d.org/wiki/love.graphics.newShader)
      * @since 0.9.0
      */
-    function newShader<T = undefined>(code: string): Shader<T>;
+    function newShader<T extends {[key:string]:any} = {}>(code: string): Shader<T>;
 
     /**
      * Creates a new Shader object for hardware-accelerated vertex and pixel effects.
@@ -1327,7 +1327,7 @@ declare module "love.graphics" {
      * @link [love.graphics.newShader](https://love2d.org/wiki/love.graphics.newShader)
      * @since 0.9.0
      */
-    function newShader<T = undefined>(pixelcode: string, vertexcode: string): Shader<T>;
+    function newShader<T extends {[key:string]:any} = {}>(pixelcode: string, vertexcode: string): Shader<T>;
 
     /**
      * Creates a new drawable Text object.

--- a/typings/love.graphics/functions.d.ts
+++ b/typings/love.graphics/functions.d.ts
@@ -1307,7 +1307,7 @@ declare module "love.graphics" {
      * @link [love.graphics.newShader](https://love2d.org/wiki/love.graphics.newShader)
      * @since 0.9.0
      */
-    function newShader<T extends {[key:string]:any} = {}>(code: string): Shader<T>;
+    function newShader<T extends {[key:string]:any} = { [key: string]: any }>(code: string): Shader<T>;
 
     /**
      * Creates a new Shader object for hardware-accelerated vertex and pixel effects.

--- a/typings/love.graphics/functions.d.ts
+++ b/typings/love.graphics/functions.d.ts
@@ -1327,7 +1327,10 @@ declare module "love.graphics" {
      * @link [love.graphics.newShader](https://love2d.org/wiki/love.graphics.newShader)
      * @since 0.9.0
      */
-    function newShader<T extends { [key: string]: any } = {}>(pixelcode: string, vertexcode: string): Shader<T>;
+    function newShader<T extends { [key: string]: any } = { [key: string]: any }>(
+        pixelcode: string,
+        vertexcode: string
+    ): Shader<T>;
 
     /**
      * Creates a new drawable Text object.

--- a/typings/love.graphics/functions.d.ts
+++ b/typings/love.graphics/functions.d.ts
@@ -1307,7 +1307,7 @@ declare module "love.graphics" {
      * @link [love.graphics.newShader](https://love2d.org/wiki/love.graphics.newShader)
      * @since 0.9.0
      */
-    function newShader<T extends {[key:string]:any} = { [key: string]: any }>(code: string): Shader<T>;
+    function newShader<T extends { [key: string]: any } = { [key: string]: any }>(code: string): Shader<T>;
 
     /**
      * Creates a new Shader object for hardware-accelerated vertex and pixel effects.
@@ -1327,7 +1327,7 @@ declare module "love.graphics" {
      * @link [love.graphics.newShader](https://love2d.org/wiki/love.graphics.newShader)
      * @since 0.9.0
      */
-    function newShader<T extends {[key:string]:any} = {}>(pixelcode: string, vertexcode: string): Shader<T>;
+    function newShader<T extends { [key: string]: any } = {}>(pixelcode: string, vertexcode: string): Shader<T>;
 
     /**
      * Creates a new drawable Text object.


### PR DESCRIPTION
I was seeing this error when compiling with `tstl`.
```
[{
	"resource": "****/node_modules/love-typescript-definitions/typings/love.graphics/functions.d.ts",
	"owner": "typescript",
	"code": "2344",
	"severity": 8,
	"message": "Type 'T' does not satisfy the constraint '{ [key: string]: any; } | undefined'.\n  Type 'T' is not assignable to type '{ [key: string]: any; }'.",
	"source": "ts",
	"startLineNumber": 1310,
	"startColumn": 61,
	"endLineNumber": 1310,
	"endColumn": 62,
	"relatedInformation": [
		{
			"startLineNumber": 1310,
			"startColumn": 24,
			"endLineNumber": 1310,
			"endColumn": 37,
			"message": "This type parameter might need an `extends { [key: string]: any; }` constraint.",
			"resource": "****/node_modules/love-typescript-definitions/typings/love.graphics/functions.d.ts"
		},
		{
			"startLineNumber": 1310,
			"startColumn": 24,
			"endLineNumber": 1310,
			"endColumn": 37,
			"message": "This type parameter might need an `extends { [key: string]: any; } | undefined` constraint.",
			"resource": "****/node_modules/love-typescript-definitions/typings/love.graphics/functions.d.ts"
		}
	]
}]
```
My changes seem to fix this error.